### PR TITLE
scroll fix

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -15,16 +15,14 @@ const Home = () => {
             <section
                 id="about">
                 <Heading
-                    title="ABOUT"
-                    style={{marginTop: 0}} />
+                    title="ABOUT"/>
                 <About />
             </section>
             <section
                 className={`${classes.faqsMarginBottom}`}
                 id="faqs">
                 <Heading
-                    title="FAQs" 
-                    style={{marginTop: 0}}/>
+                    title="FAQs"/>
                 <FAQ />
             </section>
         </main>


### PR DESCRIPTION
removed margin from headings for About and FAQ's so the entire heading is displayed and not scrolled half past