### PR TITLE
Hide genres until tbd

### DIFF
--- a/src/components/layout/MainNavigation.js
+++ b/src/components/layout/MainNavigation.js
@@ -83,7 +83,8 @@ function MainNavigation() {
                             <p>FAQ</p>
                         </Link>
                     </li>
-                    <li>
+                    {/** Bring back when we do have lines */}
+                    {/* <li>
                         <NavLink
                             aria-label="Navigation link to the genres page."
                             to="/genres"
@@ -91,7 +92,7 @@ function MainNavigation() {
                             className={({ isActive }) => isActive ? classes.active : undefined}>
                             <p>Genres</p>
                         </NavLink>
-                    </li>
+                    </li> */}
                     <li>
                         <NavLink
                             aria-label="Navigation link to the gallery page."

--- a/src/hooks/useRoutes.js
+++ b/src/hooks/useRoutes.js
@@ -20,7 +20,7 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <Home /> },
       { path: "cart", element: <Cart/> },
-      { path: "genres", element: <Genres /> },
+      // { path: "genres", element: <Genres /> },
       { path: "checkout", element: <Checkout /> },
       { path: "contact", element: <Contact /> },
       { path: "products/:category", element: <Products /> },


### PR DESCRIPTION
Does not display genres as a navigation item. The route is also inaccessible the user will hit the error page. After we have categories images this page will be useful until then we are leaving the code but w/o user access.